### PR TITLE
add per-chain permissions for addBlock

### DIFF
--- a/contracts/Braided.sol
+++ b/contracts/Braided.sol
@@ -27,7 +27,7 @@ contract Braided is BraidedInterface, Superuser {
   string constant NO_PERMISSION = "no permission";
 
   // roles
-  string constant ROLE_ADD_BLOCK = "addBlock";
+  mapping (uint => Roles.Role) private addBlockRoles;
 
   Chain[] public chains;
   mapping(uint => uint) internal chainIndexByChainID;
@@ -80,19 +80,19 @@ contract Braided is BraidedInterface, Superuser {
   }
 
   // grant role to specified account
-  function addAgent(address agent) external onlyOwnerOrSuperuser() {
-    addRole(agent, ROLE_ADD_BLOCK);
+  function addAgent(address agent, uint chainID) external onlyOwnerOrSuperuser() validChainID(chainID) {
+    addBlockRoles[chainID].add(agent);
   }
 
   // revoke role from specied account
-  function removeAgent(address agent) external onlyOwnerOrSuperuser() {
-    removeRole(agent, ROLE_ADD_BLOCK);
+  function removeAgent(address agent, uint chainID) external onlyOwnerOrSuperuser() validChainID(chainID) {
+    addBlockRoles[chainID].remove(agent);
   }
 
   // add a block to the specified chain
   function addBlock(uint chainID, uint blockNumber, bytes32 blockHash) external validChainID(chainID) {
     // caller must have permission
-    require(hasRole(msg.sender, ROLE_ADD_BLOCK), NO_PERMISSION);
+    require(addBlockRoles[chainID].has(msg.sender), NO_PERMISSION);
     // the block numbers must increase
     require(blocks[chainID].length == 0 || blocks[chainID][blocks[chainID].length - 1].blockNumber < blockNumber, INVALID_BLOCK);
     // add the block

--- a/contracts/BraidedInterface.sol
+++ b/contracts/BraidedInterface.sol
@@ -7,8 +7,8 @@ interface BraidedInterface {
   function getBraidedContract(uint) external view returns (address);
   function getGenesisBlockHash(uint) external view returns (bytes32);
   function getChainDescription(uint) external view returns (string);
-  function addAgent(address) external;
-  function removeAgent(address) external;
+  function addAgent(address, uint) external;
+  function removeAgent(address, uint) external;
   function addBlock(uint, uint, bytes32) external;
   function getBlockHash(uint, uint) external view returns (bytes32);
   function getHighestBlockNumber(uint) external view returns (uint);

--- a/test/Agent.js
+++ b/test/Agent.js
@@ -60,21 +60,24 @@ contract('Braided', (accounts) => {
         contracts.push(await Braided.new())
       }
 
-      // add chains
+      // add chains, and permissions for agents to add blocks to those chains
       for (let c = 0; c < chainCount; c++) {
-        await contracts[c].addAgent(accounts[c + 1], { from: superuser })
         if (c !== 0) {
           await contracts[c].addChain(1, contracts[0].contract.address, mainnetGenesis,
             'Foundation', { from: superuser })
+          await contracts[c].addAgent(accounts[c + 1], 1, { from: superuser })
         }
         if (c !== 1) {
           await contracts[c].addChain(2, contracts[1].contract.address, mordenGenesis, 'morden', { from: superuser })
+          await contracts[c].addAgent(accounts[c + 1], 2, { from: superuser })
         }
         if (c !== 2) {
           await contracts[c].addChain(3, contracts[2].contract.address, ropstenGenesis, 'Ropsten', { from: superuser })
+          await contracts[c].addAgent(accounts[c + 1], 3, { from: superuser })
         }
         if (c !== 3) {
           await contracts[c].addChain(4, contracts[3].contract.address, kovanGenesis, 'Kovan', { from: superuser })
+          await contracts[c].addAgent(accounts[c + 1], 4, { from: superuser })
         }
 
         // each chain should have all but itself

--- a/test/Braided.js
+++ b/test/Braided.js
@@ -70,32 +70,6 @@ contract('Braided', (accounts) => {
     it('should allow superuser to set new owner', async () => {
       await braided.transferOwnership(owner1, { from: superuser })
     })
-
-    it('should allow owner to add agents', async () => {
-      await braided.addAgent(agent1, { from: owner1 })
-      await braided.addAgent(agent2, { from: owner1 })
-    })
-
-    it('should allow superuser to add agents', async () => {
-      await braided.addAgent(agent3, { from: superuser })
-      await braided.addAgent(agent4, { from: superuser })
-    })
-
-    it('should not allow non-superuser/non-owner to add agent', async () => {
-      await expectThrow(braided.addAgent(agent1, { from: owner2 }))
-    })
-
-    it('should allow superuser to remove agent', async () => {
-      await braided.removeAgent(agent2, { from: superuser })
-    })
-
-    it('should allow owner to remove agent', async () => {
-      await braided.removeAgent(agent3, { from: owner1 })
-    })
-
-    it('should not allow non-superuser/non-owner to remove agent', async () => {
-      await expectThrow(braided.addAgent(agent1, { from: owner2 }))
-    })
   })
 
   // Test linking multiple testnets together
@@ -132,7 +106,39 @@ contract('Braided', (accounts) => {
       // ensure unmodified
       (await braided.getGenesisBlockHash(mainnetID)).should.be.eq(mainnetGenesis)
     })
+  })
 
+  context('Add agents', () => {
+    it('should add chains', async () => {
+      await braided.addAgent(agent1, mainnetID, { from: owner1 })
+      await braided.addAgent(agent2, mainnetID, { from: owner1 })
+    })
+
+    it('should allow superuser to add agents', async () => {
+      await braided.addAgent(agent3, mainnetID, { from: superuser })
+      await braided.addAgent(agent4, mainnetID, { from: superuser })
+      await braided.addAgent(agent4, ropstenID, { from: superuser })
+      await braided.addAgent(agent4, classicID, { from: superuser })
+    })
+
+    it('should not allow non-superuser/non-owner to add agent', async () => {
+      await expectThrow(braided.addAgent(agent1, mainnetID, { from: owner2 }))
+    })
+
+    it('should allow superuser to remove agent', async () => {
+      await braided.removeAgent(agent2, mainnetID, { from: superuser })
+    })
+
+    it('should allow owner to remove agent', async () => {
+      await braided.removeAgent(agent3, mainnetID, { from: owner1 })
+    })
+
+    it('should not allow non-superuser/non-owner to remove agent', async () => {
+      await expectThrow(braided.addAgent(agent1, mainnetID, { from: owner2 }))
+    })
+  })
+
+  context('set and get hashes', () => {
     it('should allow agents to add hashes', async () => {
       await braided.addBlock(mainnetID, 1, mainnet1, { from: agent1 })
       await braided.addBlock(mainnetID, 2, mainnet2, { from: agent1 })


### PR DESCRIPTION
Use OpenZeppelin's `Roles` class directly instead of RBAC (which is deprecated in 2.0), following [discussion](https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1290). Thanks @nventuro!